### PR TITLE
Feature/3 server discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["Damon Myers <damon.shane.myers@gmail.com>"]
 actix-web = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
+toml = "0.4"

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+    "bind_address": "127.0.0.1",
+    "port": 8000,
+    "domain": "localhost"
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-    "bind_address": "127.0.0.1",
-    "port": 8000,
-    "domain": "localhost"
-}

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,6 @@
+# The address to listen for connections on. Defaults to 127.0.0.1
+bind_address = "127.0.0.1"
+# The port to listen for connections on. Defaults to 8000
+port = 8000
+# The DNS name for the server. Defaults to "localhost"
+domain = "localhost"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,8 @@
-use serde_json;
 use std::error::Error;
 use std::fs::File;
+use std::io::Read;
 use std::path::Path;
+use toml;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
@@ -14,8 +15,11 @@ pub struct Config {
 }
 
 pub fn load_config(filepath: &Path) -> Result<Config, Box<Error>> {
-    let file = File::open(filepath)?;
-    let contents = serde_json::from_reader(file)?;
+    let mut file = File::open(filepath)?;
+    let mut toml_str = String::new();
+    file.read_to_string(&mut toml_str)?;
 
-    Ok(contents)
+    let config = toml::from_str(&toml_str)?;
+
+    Ok(config)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,21 @@
+use serde_json;
+use std::error::Error;
+use std::fs::File;
+use std::path::Path;
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct Config {
+    // The address to listen for connections on. Defaults to 127.0.0.1
+    pub bind_address: String,
+    // The port to listen for connections on. Defaults to 8000
+    pub port: u16,
+    // The DNS name for the server. Defaults to "localhost"
+    pub domain: String,
+}
+
+pub fn load_config(filepath: &Path) -> Result<Config, Box<Error>> {
+    let file = File::open(filepath)?;
+    let contents = serde_json::from_reader(file)?;
+
+    Ok(contents)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,45 @@
 #[macro_use]
 extern crate serde_derive;
-
 extern crate actix_web;
-mod routes;
+extern crate serde_json;
 
-use actix_web::{server, App};
+mod config;
+mod routes;
+mod state;
+
+use actix_web::{http::Method, server, App};
+use state::AppState;
+use std::path::Path;
+use std::result::Result;
 
 fn main() {
-    server::new(|| {
-        App::new().resource("/_matrix/client/versions", |r| {
-            r.f(routes::version::versions)
-        })
-    }).bind("127.0.0.1:8000")
-    .expect("Can not bind to port 8000")
+    let config_json = load_config_from_default_path();
+    let config_clone = config_json.clone();
+
+    server::new(move || {
+        App::with_state(AppState::from(&config_clone))
+            .resource("/_matrix/client/versions", |r| {
+                r.method(Method::GET).f(routes::version::versions)
+            }).resource("/.well-known/matrix/client", |r| {
+                r.method(Method::GET).f(routes::discovery::well_known)
+            })
+    }).bind(format!("{}:{}", config_json.bind_address, config_json.port))
+    .expect(&format!("Can not bind to port {}\n", config_json.port))
     .run();
+}
+
+fn load_config_from_default_path() -> config::Config {
+    let config_path = Path::new("./config.json");
+
+    match config::load_config(config_path) {
+        Result::Ok(loaded_config) => loaded_config,
+        Result::Err(_) => {
+            println!("Failed to load config.json, using default values.");
+            config::Config {
+                bind_address: String::from("127.0.0.1"),
+                port: 8000,
+                domain: String::from("localhost"),
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate serde_derive;
 extern crate actix_web;
-extern crate serde_json;
+extern crate toml;
 
 mod config;
 mod routes;
@@ -13,8 +13,8 @@ use std::path::Path;
 use std::result::Result;
 
 fn main() {
-    let config_json = load_config_from_default_path();
-    let config_clone = config_json.clone();
+    let loaded_config = load_config_from_default_path();
+    let config_clone = loaded_config.clone();
 
     server::new(move || {
         App::with_state(AppState::from(&config_clone))
@@ -23,18 +23,20 @@ fn main() {
             }).resource("/.well-known/matrix/client", |r| {
                 r.method(Method::GET).f(routes::discovery::well_known)
             })
-    }).bind(format!("{}:{}", config_json.bind_address, config_json.port))
-    .expect(&format!("Can not bind to port {}\n", config_json.port))
+    }).bind(format!(
+        "{}:{}",
+        loaded_config.bind_address, loaded_config.port
+    )).expect(&format!("Can not bind to port {}\n", loaded_config.port))
     .run();
 }
 
 fn load_config_from_default_path() -> config::Config {
-    let config_path = Path::new("./config.json");
+    let config_path = Path::new("./config.toml");
 
     match config::load_config(config_path) {
         Result::Ok(loaded_config) => loaded_config,
         Result::Err(_) => {
-            println!("Failed to load config.json, using default values.");
+            println!("Failed to load config.toml, using default values.");
             config::Config {
                 bind_address: String::from("127.0.0.1"),
                 port: 8000,

--- a/src/routes/discovery/mod.rs
+++ b/src/routes/discovery/mod.rs
@@ -1,0 +1,22 @@
+use actix_web::error::Error;
+use actix_web::{HttpRequest, Json};
+use state::AppState;
+
+#[derive(Serialize)]
+pub struct HomeserverData {
+    base_url: String,
+}
+
+#[derive(Serialize)]
+pub struct WellKnownData {
+    #[serde(rename = "m.homeserver")]
+    m_homeserver: HomeserverData,
+}
+
+pub fn well_known(req: &HttpRequest<AppState>) -> Result<Json<WellKnownData>, Error> {
+    let domain = req.state().domain.clone();
+
+    Ok(Json(WellKnownData {
+        m_homeserver: HomeserverData { base_url: domain },
+    }))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,1 +1,2 @@
+pub mod discovery;
 pub mod version;

--- a/src/routes/version/mod.rs
+++ b/src/routes/version/mod.rs
@@ -1,5 +1,6 @@
 use actix_web::error::Error;
 use actix_web::{HttpRequest, Json};
+use state::AppState;
 
 const VERSION_SUPPORTED: &str = "r0.4.0";
 
@@ -8,7 +9,7 @@ pub struct Versions {
     versions: Vec<&'static str>,
 }
 
-pub fn versions(_: &HttpRequest) -> Result<Json<Versions>, Error> {
+pub fn versions(_: &HttpRequest<AppState>) -> Result<Json<Versions>, Error> {
     Ok(Json(Versions {
         versions: vec![VERSION_SUPPORTED],
     }))

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,14 @@
+use config::Config;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub domain: String,
+}
+
+impl AppState {
+    pub fn from(config: &Config) -> AppState {
+        AppState {
+            domain: config.domain.clone(),
+        }
+    }
+}


### PR DESCRIPTION
Closes #3 

Adds the server discovery endpoint as well as a crude implementation of a config.json file. Currently expects the file to live in the working directory when the server is started. Configuration options are bind address, port, and domain.